### PR TITLE
Fix/localization

### DIFF
--- a/src/Cogworks.ExamineInspector/Cogworks.ExamineInspector.csproj
+++ b/src/Cogworks.ExamineInspector/Cogworks.ExamineInspector.csproj
@@ -333,6 +333,16 @@
   <ItemGroup>
     <None Include="Web\UI\App_Plugins\ExamineInspector\dashboard\filters\examineinspector.filters.js" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Web\UI\App_Plugins\ExamineInspector\lang\en-US.xml">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Web\UI\App_Plugins\ExamineInspector\lang\pl-PL.xml">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy /S /H /Y /I /E "$(ProjectDir)Web\UI\*.*" "$(ProjectDir)..\Website\"</PostBuildEvent>

--- a/src/Cogworks.ExamineInspector/Web/UI/App_Plugins/ExamineInspector/lang/en-GB.xml
+++ b/src/Cogworks.ExamineInspector/Web/UI/App_Plugins/ExamineInspector/lang/en-GB.xml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<language alias="en" intName="English" localName="english" lcid="1" culture="en-GB">
+<language alias="en" intName="English" localName="english" lcid="" culture="en-GB">
   <creator>
     <name>Ismail Mayat // Alejandro Ocampo @ The Cogworks</name>
-    <link>http://mydomain.com</link>
+    <link>https://thecogworks.com</link>
   </creator>
   <area alias="examineInspector">
     <key alias="chooseIndexOption">Please select index option</key>
-    <key alias="selectIndexLabel">-- Select Index --</key>
+    <key alias="selectIndexLabel">-- Select index --</key>
 
     <key alias="overview">Overview</key>
     <key alias="viewing">Viewing: </key>
@@ -18,32 +18,32 @@
     <key alias="display">Display</key>
     <key alias="availableFields">Available fields</key>
     <key alias="namesField">Names</key>
-    <key alias="selectAll">Select All</key>
-    <key alias="showingTopTerms">Showing Top Terms</key>
+    <key alias="selectAll">Select all</key>
+    <key alias="showingTopTerms">Showing top terms</key>
     <key alias="selectAvailableFields">Select available fields below</key>
 
     <key alias="usingDocId">Using DocId:</key>
-    <key alias="results">Results:</key>
+    <key alias="results">Results</key>
     <key alias="moreInfo">Select row for more information</key>
-    <key alias="documentInfo">Document Info:</key>
+    <key alias="documentInfo">Document info</key>
     <key alias="search">Search</key>
     <key alias="indexFiles">Index files</key>
     <key alias="analyse">Analyse</key>
     <key alias="analyser">Analyser</key>
     <key alias="defaultField">Default field</key>
-    <key alias="chooseAnalyserOption">-- Select Analyser --</key>
+    <key alias="chooseAnalyserOption">-- Select analyser --</key>
     <key alias="chooseDefaultField">-- Select default field --</key>
     <key alias="luceneQuery">Enter lucene query here</key>
     <key alias="query">Query</key>
     <key alias="fieldsToDisplay">Fields to display</key>
-    <key alias="selectFieldsToDisplay">-- Select Fields To Display --</key>
+    <key alias="selectFieldsToDisplay">-- Select fields to display --</key>
     <key alias="noResults">There are no results to show.</key>
 
-    <key alias="totalIndexSize">Total Index Size:</key>
-    <key alias="fileName">File Name</key>
-    <key alias="fileSize">File Size</key>
+    <key alias="totalIndexSize">Total index size:</key>
+    <key alias="fileName">File name</key>
+    <key alias="fileSize">File size</key>
 
     <key alias="enterTextToAnalyse">Enter text to analyse here</key>
-    <key alias="generatedTokens">Generated Tokens</key>
+    <key alias="generatedTokens">Generated tokens</key>
   </area>
 </language>

--- a/src/Cogworks.ExamineInspector/Web/UI/App_Plugins/ExamineInspector/lang/en-US.xml
+++ b/src/Cogworks.ExamineInspector/Web/UI/App_Plugins/ExamineInspector/lang/en-US.xml
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="en_us" intName="English (US)" localName="English (US)" lcid="" culture="en-US">
+  <creator>
+    <name>Ismail Mayat // Alejandro Ocampo @ The Cogworks</name>
+    <link>https://thecogworks.com</link>
+  </creator>
+  <area alias="examineInspector">
+    <key alias="chooseIndexOption">Please select index option</key>
+    <key alias="selectIndexLabel">-- Select index --</key>
+
+    <key alias="overview">Overview</key>
+    <key alias="viewing">Viewing: </key>
+    <key alias="path">Path: </key>
+    <key alias="noOfFields">Number of fields</key>
+    <key alias="noOfDocuments">Number of documents</key>
+    <key alias="noOfTerms">Number of terms</key>
+    <key alias="noOfTermsToShow">No. of terms to show</key>
+    <key alias="display">Display</key>
+    <key alias="availableFields">Available fields</key>
+    <key alias="namesField">Names</key>
+    <key alias="selectAll">Select all</key>
+    <key alias="showingTopTerms">Showing top terms</key>
+    <key alias="selectAvailableFields">Select available fields below</key>
+
+    <key alias="usingDocId">Using DocId:</key>
+    <key alias="results">Results</key>
+    <key alias="moreInfo">Select row for more information</key>
+    <key alias="documentInfo">Document info</key>
+    <key alias="search">Search</key>
+    <key alias="indexFiles">Index files</key>
+    <key alias="analyse">Analyse</key>
+    <key alias="analyser">Analyser</key>
+    <key alias="defaultField">Default field</key>
+    <key alias="chooseAnalyserOption">-- Select analyser --</key>
+    <key alias="chooseDefaultField">-- Select default field --</key>
+    <key alias="luceneQuery">Enter lucene query here</key>
+    <key alias="query">Query</key>
+    <key alias="fieldsToDisplay">Fields to display</key>
+    <key alias="selectFieldsToDisplay">-- Select fields to display --</key>
+    <key alias="noResults">There are no results to show.</key>
+
+    <key alias="totalIndexSize">Total index size:</key>
+    <key alias="fileName">File name</key>
+    <key alias="fileSize">File size</key>
+
+    <key alias="enterTextToAnalyse">Enter text to analyse here</key>
+    <key alias="generatedTokens">Generated tokens</key>
+  </area>
+</language>

--- a/src/Cogworks.ExamineInspector/Web/UI/App_Plugins/ExamineInspector/lang/pl-PL.xml
+++ b/src/Cogworks.ExamineInspector/Web/UI/App_Plugins/ExamineInspector/lang/pl-PL.xml
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="pl" intName="Polish" localName="polski" lcid="21" culture="pl-PL">
+  <creator>
+    <name>Marcin Zajkowski @ The Cogworks</name>
+    <link>https://thecogworks.com</link>
+  </creator>
+  <area alias="examineInspector">
+    <key alias="chooseIndexOption">Wybierz opcje indeksu</key>
+    <key alias="selectIndexLabel">-- Wybierz indeks --</key>
+
+    <key alias="overview">Przegląd</key>
+    <key alias="viewing">Indeks: </key>
+    <key alias="path">Ścieżka: </key>
+    <key alias="noOfFields">Liczba pól</key>
+    <key alias="noOfDocuments">Liczba dokumentów</key>
+    <key alias="noOfTerms">Liczba wyrażeń</key>
+    <key alias="noOfTermsToShow">Liczba widocznych wyrażeń</key>
+    <key alias="display">Pokaż</key>
+    <key alias="availableFields">Dostępne pola</key>
+    <key alias="namesField">Nazwy</key>
+    <key alias="selectAll">Zaznacz wszystko</key>
+    <key alias="showingTopTerms">Podgląd topowych wyrażeń</key>
+    <key alias="selectAvailableFields">Wybierz jaka ilość wyrażeń ma być wyświetlana na poniższej liście</key>
+
+    <key alias="usingDocId">Używany DocId:</key>
+    <key alias="results">Wyniki</key>
+    <key alias="moreInfo">Zaznacz pojedynczy wiersz aby dowiedzieć się więcej</key>
+    <key alias="documentInfo">Informacje o dokumencie</key>
+    <key alias="search">Wyszukaj</key>
+    <key alias="indexFiles">Pliki indeksu</key>
+    <key alias="analyse">Analizuj</key>
+    <key alias="analyser">Analizator</key>
+    <key alias="defaultField">Domyślne pole</key>
+    <key alias="chooseAnalyserOption">-- Wybierz analizator --</key>
+    <key alias="chooseDefaultField">-- Wybierz domyślne pole --</key>
+    <key alias="luceneQuery">Wprowadź zapytanie  lucene</key>
+    <key alias="query">Zapytanie</key>
+    <key alias="fieldsToDisplay">Pola do wyświetlenia</key>
+    <key alias="selectFieldsToDisplay">-- Wybierz pola do wyświetlenia --</key>
+    <key alias="noResults">Brak wyników wyszukiwania.</key>
+
+    <key alias="totalIndexSize">Całkowity rozmiar indeksu:</key>
+    <key alias="fileName">Nazwa pliku</key>
+    <key alias="fileSize">Rozmiar pliku</key>
+
+    <key alias="enterTextToAnalyse">Wprowadź tekst do analizy</key>
+    <key alias="generatedTokens">Wygenerowane tokeny</key>
+  </area>
+</language>

--- a/src/Website/App_Plugins/ExamineInspector/lang/en-US.xml
+++ b/src/Website/App_Plugins/ExamineInspector/lang/en-US.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<language alias="en" intName="English" localName="english" lcid="" culture="en-GB">
+<language alias="en_us" intName="English (US)" localName="English (US)" lcid="" culture="en-US">
   <creator>
     <name>Ismail Mayat // Alejandro Ocampo @ The Cogworks</name>
     <link>https://thecogworks.com</link>

--- a/src/Website/App_Plugins/ExamineInspector/lang/pl-PL.xml
+++ b/src/Website/App_Plugins/ExamineInspector/lang/pl-PL.xml
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="pl" intName="Polish" localName="polski" lcid="21" culture="pl-PL">
+  <creator>
+    <name>Marcin Zajkowski @ The Cogworks</name>
+    <link>https://thecogworks.com</link>
+  </creator>
+  <area alias="examineInspector">
+    <key alias="chooseIndexOption">Wybierz opcje indeksu</key>
+    <key alias="selectIndexLabel">-- Wybierz indeks --</key>
+
+    <key alias="overview">Przegląd</key>
+    <key alias="viewing">Indeks: </key>
+    <key alias="path">Ścieżka: </key>
+    <key alias="noOfFields">Liczba pól</key>
+    <key alias="noOfDocuments">Liczba dokumentów</key>
+    <key alias="noOfTerms">Liczba wyrażeń</key>
+    <key alias="noOfTermsToShow">Liczba widocznych wyrażeń</key>
+    <key alias="display">Pokaż</key>
+    <key alias="availableFields">Dostępne pola</key>
+    <key alias="namesField">Nazwy</key>
+    <key alias="selectAll">Zaznacz wszystko</key>
+    <key alias="showingTopTerms">Podgląd topowych wyrażeń</key>
+    <key alias="selectAvailableFields">Wybierz jaka ilość wyrażeń ma być wyświetlana na poniższej liście</key>
+
+    <key alias="usingDocId">Używany DocId:</key>
+    <key alias="results">Wyniki</key>
+    <key alias="moreInfo">Zaznacz pojedynczy wiersz aby dowiedzieć się więcej</key>
+    <key alias="documentInfo">Informacje o dokumencie</key>
+    <key alias="search">Wyszukaj</key>
+    <key alias="indexFiles">Pliki indeksu</key>
+    <key alias="analyse">Analizuj</key>
+    <key alias="analyser">Analizator</key>
+    <key alias="defaultField">Domyślne pole</key>
+    <key alias="chooseAnalyserOption">-- Wybierz analizator --</key>
+    <key alias="chooseDefaultField">-- Wybierz domyślne pole --</key>
+    <key alias="luceneQuery">Wprowadź zapytanie  lucene</key>
+    <key alias="query">Zapytanie</key>
+    <key alias="fieldsToDisplay">Pola do wyświetlenia</key>
+    <key alias="selectFieldsToDisplay">-- Wybierz pola do wyświetlenia --</key>
+    <key alias="noResults">Brak wyników wyszukiwania.</key>
+
+    <key alias="totalIndexSize">Całkowity rozmiar indeksu:</key>
+    <key alias="fileName">Nazwa pliku</key>
+    <key alias="fileSize">Rozmiar pliku</key>
+
+    <key alias="enterTextToAnalyse">Wprowadź tekst do analizy</key>
+    <key alias="generatedTokens">Wygenerowane tokeny</key>
+  </area>
+</language>


### PR DESCRIPTION
As in raised issue here: https://github.com/thecogworks/examineinspector/issues/1, we were not shipping by default translations for en-US culture which is selected by default in all new Umbraco installations. Because of it we were having empty keys without any fallback.

I've added missing file, improved some translations to make it consistent with UI and added Polish translations as well.